### PR TITLE
c3tt client enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ It publishes recordings an handles all necessary steps like thumbnail generation
 ## Dependencies
 ### Debian / Ubuntu
 ```
-sudo apt-get install python3 python3-requests python3-pip ffmpeg
-pip3 install paramiko configparser twitter mastodon.py
+sudo apt-get install python3 python3-requests python3-pip ffmpeg timelens
+pip3 install -r requirements.txt
 ```
 
 ## Usage

--- a/voctopublish/api_client/c3tt_rpc_client.py
+++ b/voctopublish/api_client/c3tt_rpc_client.py
@@ -139,16 +139,17 @@ class C3TTClient:
         """
         return str(self._open_rpc("C3TT.getVersion"))
 
-    def assign_next_unassigned_for_state(self, ticket_type, to_state):
+    def assign_next_unassigned_for_state(self, ticket_type, to_state, property_filters = []):
         """
         check for new ticket on tracker and get assignment
         this also sets the ticket id in the c3tt client instance and has therefore be called before any ticket related
         function
         :param ticket_type: type of ticket
         :param to_state: ticket state the returned ticket will be in after this call
+        :parm property_filters:  return only tickets matching given properties
         :return: ticket id or None in case no ticket is available for the type and state in the request
         """
-        ret = self._open_rpc("C3TT.assignNextUnassignedForState", [ticket_type, to_state])
+        ret = self._open_rpc("C3TT.assignNextUnassignedForState", [ticket_type, to_state, property_filters])
         # if we get no xml here there is no ticket for this job
         if not ret:
             return None

--- a/voctopublish/api_client/c3tt_rpc_client.py
+++ b/voctopublish/api_client/c3tt_rpc_client.py
@@ -156,6 +156,41 @@ class C3TTClient:
         else:
             self.ticket_id = ret['id']
             return ret['id']
+            
+    def get_assigned_for_state(self, ticket_type, state, property_filters = []):
+        """
+        Get first assigned ticket in state $state
+        function
+        :param ticket_type: type of ticket
+        :param to_state: ticket state the returned ticket will be in after this call
+        :parm property_filters: return only tickets matching given properties
+        :return: ticket id or None in case no ticket is available for the type and state in the request
+        """
+        ret = self._open_rpc("C3TT.getAssignedForState", [ticket_type, state, property_filters])
+        # if we get no xml here there is no ticket for this job
+        if not ret:
+            return None
+        else:
+            if len(ret) > 1:
+                logging.warn("multiple tickets assined, fetching first one")
+            self.ticket_id = ret[0]['id']
+            return ret['id']
+
+    def get_tickets_for_state(self, ticket_type, to_state, property_filters = []):
+        """
+        Get all tickets in state $state from projects assigned to the workerGroup, unless workerGroup is halted
+        function
+        :param ticket_type: type of ticket
+        :param to_state: ticket state the returned ticket will be in after this call
+        :parm property_filters: return only tickets matching given properties
+        :return: ticket id or None in case no ticket is available for the type and state in the request
+        """
+        ret = self._open_rpc("C3TT.getTicketsForState", [ticket_type, to_state, property_filters])
+        # if we get no xml here there is no ticket for this job
+        if not ret:
+            return None
+        else:
+            return ret
 
     def set_ticket_properties(self, properties):
         """

--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -27,7 +27,7 @@ class Ticket:
         if not ticket:
             raise TicketException('Ticket was None type')
         self.__tracker_ticket = ticket
-        self.ticket_id = ticket_id
+        self.id = ticket_id
 
         # project properties
         self.acronym = self._validate_('Project.Slug')

--- a/voctopublish/test/api_client_test/test_c3tt_rpc_client.py
+++ b/voctopublish/test/api_client_test/test_c3tt_rpc_client.py
@@ -15,7 +15,6 @@ class TestC3TTClient(unittest.TestCase):
 
     def test_init(self):
         assert self._client.url == "<server>rpc" # todo shouldn't this be an _url join?
-        assert self._client.ticket_id is None
 
     def test_gen_signature_args_empty(self):
         hash_ = self._client._gen_signature("test", [])

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -293,6 +293,7 @@ class Publisher:
         # now, after we reported everything back to the tracker, we try to add the videos to our own playlists
         # second YoutubeAPI instance for playlist management at youtube.com
         # todo figure out why we need two tokens
+	# answer: if the playlist is on a different youtube channel, then the one we upload the videos to --Andi
         if 'playlist_token' in self.config['youtube'] and self.ticket.youtube_token != self.config['youtube']['playlist_token']:
             yt_voctoweb = YoutubeAPI(self.ticket, self.config['youtube']['client_id'], self.config['youtube']['secret'])
             yt_voctoweb.setup(self.config['youtube']['playlist_token'])


### PR DESCRIPTION
This PR
- add the property filter parameter to the c3tt ticket query methods
- make the C3TTClient class stateless, by moving `ticket_id` from a instance variable into parameters