### PR TITLE
voctopublish: add option to execute arbitrary shell commands on publish

### DIFF
--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -144,6 +144,12 @@ class Ticket:
             self.recording_id = self._validate_('Voctoweb.RecordingId.Master', True)
             self.voctoweb_event_id = self._validate_('Voctoweb.EventId', True)
 
+        # shell commands
+        self.shell_commands = {}
+        for key in ticket:
+            if key.startswith('Publishing.ShellCommands.'):
+                self.shell_commands[key] = self._validate_(key)
+
         # twitter properties
         if self._validate_('Publishing.Twitter.Enable') == 'yes':
             self.twitter_enable = True

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -139,6 +139,23 @@ class Publisher:
         else:
             logging.debug("no youtube :(")
 
+        if self.ticket.shell_commands and self.ticket.master:
+            if self.config.get('general', {}).get('enable_shell_commands', False):
+                for identifier, command in self.ticket.shell_commands.items():
+                    try:
+                        for line in subprocess.check_output(
+                            command.format(
+                                source_file_name=self.ticket.local_filename,
+                                source_full_path=os.path.join(self.ticket.publishing_path, self.ticket.local_filename),
+                            ),
+                            shell=True
+                        ).decode().splitlines():
+                            logging.info(identifier + ": " + line)
+                    except subprocess.CalledProcessError as e:
+                        raise PublisherException(identifier + " failed: " + repr(e))
+            else:
+                raise PublisherException("Shell Commands requested but not enabled in voctopublish config")
+
         logging.debug('#done')
         self.c3tt.set_ticket_done(self.ticket)
 


### PR DESCRIPTION
We're using this to sync encoded master files to a google drive storage, using `rclone`.

Yes, i know this could lead to someone executing malicious code on the machine running voctopublish, which is why this must be enabled explicitely in the voctopublish config. If disabled or not set at all, publishing will fail if you set shell commands.