### PR TITLE
voctopublish: add option to execute arbitrary shell commands on publish

### DIFF
--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -215,6 +215,12 @@ class PublishingTicket(Ticket):
             self.recording_id = self._validate_('Voctoweb.RecordingId.Master', True)
             self.voctoweb_event_id = self._validate_('Voctoweb.EventId', True)
 
+        # shell commands
+        self.shell_commands = {}
+        for key in ticket:
+            if key.startswith('Publishing.ShellCommands.'):
+                self.shell_commands[key] = self._validate_(key)
+
         # twitter properties
         if self._validate_('Publishing.Twitter.Enable') == 'yes':
             self.twitter_enable = True

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -141,6 +141,23 @@ class Worker:
         else:
             logging.debug("no youtube :(")
 
+        if self.ticket.shell_commands and self.ticket.master:
+            if self.config['general'].get('enable_shell_commands', False):
+                for identifier, command in self.ticket.shell_commands.items():
+                    try:
+                        for line in subprocess.check_output(
+                            command.format(
+                                source_file_name=self.ticket.local_filename,
+                                source_full_path=os.path.join(self.ticket.publishing_path, self.ticket.local_filename),
+                            ),
+                            shell=True
+                        ).decode().splitlines():
+                            logging.info(identifier + ": " + line)
+                    except subprocess.CalledProcessError as e:
+                        raise PublisherException(identifier + " failed: " + repr(e))
+            else:
+                raise PublisherException("Shell Commands requested but not enabled in voctopublish config")
+
         logging.debug('#done')
         self.c3tt.set_ticket_done(self.ticket)
 


### PR DESCRIPTION
This can be used to (for example) call `rclone` to sync files to a cloud storage service.

Followup to https://github.com/voc/voctopublish/pull/94