### PR TITLE
voctopublish: add rclone client

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -41,3 +41,7 @@ consumer_secret = <consumer secret>
 api_base_url = <https://mastodon.social>
 email = <loginemail>
 password = <password>
+
+[rclone]
+exe_path = <path to rclone binary>
+config_path = <path to rclone config>

--- a/voctopublish/api_client/rclone_client.py
+++ b/voctopublish/api_client/rclone_client.py
@@ -22,6 +22,7 @@ class RCloneClient:
             filename_full=self.ticket.filename,
             filename_guid=f"{self.ticket.guid}.{self.ticket.profile_extension}",
             filename_short=self.ticket.local_filename,
+            format=self.folder,
             month=date_time.strftime("%m"),
             year=date_time.strftime("%Y"),
         )

--- a/voctopublish/api_client/rclone_client.py
+++ b/voctopublish/api_client/rclone_client.py
@@ -48,10 +48,12 @@ class RCloneClient:
                 logging.warn(f"rclone reported no transferred files (return code 9)!")
             else:
                 logging.error(f"rclone exited {e.returncode}!")
-            for line in e.stdout.decode().splitlines():
-                logging.error(f"STDOUT: {line}")
-            for line in e.stderr.decode().splitlines():
-                logging.error(f"STDERR: {line}")
+            if e.stdout:
+                for line in e.stdout.decode().splitlines():
+                    logging.error(f"STDOUT: {line}")
+            if e.stderr:
+                for line in e.stderr.decode().splitlines():
+                    logging.error(f"STDERR: {line}")
             return e.returncode
         else:
             logging.info(f"uploaded to {self.destination}")

--- a/voctopublish/api_client/rclone_client.py
+++ b/voctopublish/api_client/rclone_client.py
@@ -17,12 +17,12 @@ class RCloneClient:
         date_time = datetime.strptime(t.date, "%Y-%m-%dT%H:%M:%S%z")
         self.destination = self.ticket.rclone_destination.format(
             day=date_time.strftime("%d"),
-            event=self.acronym,
+            event=self.ticket.acronym,
             fahrplan_day=self.ticket.day,
             filename_full=self.ticket.filename,
             filename_guid=f"{self.ticket.guid}.{self.ticket.profile_extension}",
             filename_short=self.ticket.local_filename,
-            format=self.folder,
+            format=self.ticket.folder,
             month=date_time.strftime("%m"),
             year=date_time.strftime("%Y"),
         )

--- a/voctopublish/api_client/rclone_client.py
+++ b/voctopublish/api_client/rclone_client.py
@@ -1,0 +1,57 @@
+import logging
+from datetime import datetime
+from os.path import join
+from subprocess import CalledProcessError, check_output
+
+from model.ticket_module import Ticket
+
+logging = logging.getLogger(__name__)
+
+
+class RCloneClient:
+    def __init__(self, t: Ticket, config):
+        self.ticket = t
+        self.rclone_path = config.get("rclone", "exe_path")
+        self.rclone_config = config.get("rclone", "config_path")
+
+        date_time = datetime.strptime(t.date, "%Y-%m-%dT%H:%M:%S%z")
+        self.destination = self.ticket.rclone_destination.format(
+            day=date_time.strftime("%d"),
+            event=self.acronym,
+            fahrplan_day=self.ticket.day,
+            filename_full=self.ticket.filename,
+            filename_guid=f"{self.ticket.guid}.{self.ticket.profile_extension}",
+            filename_short=self.ticket.local_filename,
+            month=date_time.strftime("%m"),
+            year=date_time.strftime("%Y"),
+        )
+
+    def upload(self):
+        try:
+            out = check_output(
+                [
+                    self.rclone_path,
+                    "--config",
+                    self.rclone_config,
+                    "--verbose",
+                    "--error-on-no-transfer",
+                    "copyto",
+                    join(self.ticket.publishing_path, self.ticket.local_filename),
+                    self.destination,
+                ]
+            )
+            for line in out.decode().splitlines():
+                logging.debug(line)
+        except CalledProcessError as e:
+            if e.returncode == 9:
+                logging.warn(f"rclone reported no transferred files (return code 9)!")
+            else:
+                logging.error(f"rclone exited {e.returncode}!")
+            for line in e.stdout.decode().splitlines():
+                logging.error(f"STDOUT: {line}")
+            for line in e.stderr.decode().splitlines():
+                logging.error(f"STDERR: {line}")
+            return e.returncode
+        else:
+            logging.info(f"uploaded to {self.destination}")
+            return 0

--- a/voctopublish/api_client/voctoweb_client.py
+++ b/voctopublish/api_client/voctoweb_client.py
@@ -27,7 +27,6 @@ import requests
 import glob
 
 from model.ticket_module import Ticket
-from api_client.select_thumbnail import calc_score
 from tools.thumbnails import ThumbnailGenerator
 
 

--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -25,7 +25,7 @@ class Ticket:
     def __init__(self, ticket, ticket_id):
         if not ticket:
             raise TicketException('Ticket was None type')
-        self.__tracker_ticket = ticket
+        self._tracker_ticket = ticket
         self.id = ticket_id
 
         # project properties
@@ -36,8 +36,8 @@ class Ticket:
 
     def _validate_(self, key, optional=False):
         value = None
-        if key in self.__tracker_ticket:
-            value = self.__tracker_ticket[key]
+        if key in self._tracker_ticket:
+            value = self._tracker_ticket[key]
             if not value:
                 logging.debug(key + ' is empty in ticket')
                 raise TicketException(key + ' is empty in ticket')
@@ -103,7 +103,7 @@ class PublishingTicket(Ticket):
 
         # recording ticket properties
         self.language = self._validate_('Record.Language')
-        self.languages = {int(k.split('.')[-1]): self._validate_(k) for k in self.__tracker_ticket.keys()
+        self.languages = {int(k.split('.')[-1]): self._validate_(k) for k in self._tracker_ticket
                           if k.startswith('Record.Language.')}
         self.language_template = self._validate_('Encoding.LanguageTemplate')
 
@@ -151,7 +151,7 @@ class PublishingTicket(Ticket):
             self.languages = dict(enumerate(self._validate_('Encoding.Language').split('-')))
         else:
             self.language = self._validate_('Record.Language')
-            self.languages = {int(k.split('.')[-1]): self._validate_(k) for k in self.__tracker_ticket.keys() if k.startswith('Record.Language.')}
+            self.languages = {int(k.split('.')[-1]): self._validate_(k) for k in self._tracker_ticket if k.startswith('Record.Language.')}
         self.language_template = self._validate_('Encoding.LanguageTemplate')
 
         # general publishing properties
@@ -182,7 +182,7 @@ class PublishingTicket(Ticket):
             self.youtube_translation_title_suffix = self._validate_('Publishing.YouTube.TranslationTitleSuffix', True)
             self.youtube_urls = {}
             # check if this event has already been published to youtube
-            if 'YouTube.Url0' in ticket and self._validate_('YouTube.Url0') is not None:
+            if 'YouTube.Url0' in self._tracker_ticket and self._validate_('YouTube.Url0') is not None:
                 self.has_youtube_url = True
 
                 for key in ticket:
@@ -246,8 +246,8 @@ class PublishingTicket(Ticket):
 
     def get_raw_property(self, key, optional=True):
         value = None
-        if key in self.__tracker_ticket:
-            value = self.__tracker_ticket[key]
+        if key in self._tracker_ticket:
+            value = self._tracker_ticket[key]
         else:
             if not optional:
                 logging.debug(key + ' is missing in ticket')

--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -81,7 +81,7 @@ class RecordingTicket(Ticket):
     '''
 
     def __init__(self, ticket, ticket_id):
-        Ticket.__init__(self, ticket, ticket_id)
+        super().__init__(ticket, ticket_id)
 
         # recording ticket properties
         self.download_url = self._validate_('Fahrplan.VideoDownloadURL')
@@ -99,7 +99,7 @@ class PublishingTicket(Ticket):
     '''
 
     def __init__(self, ticket, ticket_id):
-        Ticket.__init__(self, ticket, ticket_id)
+        super().__init__(ticket, ticket_id)
 
         # recording ticket properties
         self.language = self._validate_('Record.Language')

--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -29,10 +29,10 @@ class Ticket:
         self.id = ticket_id
 
         # project properties
-        self.acronym = self._validate_('Project.Slug')
+        self.acronym = ticket['Project.Slug']
 
         # general publishing properties
-        self.publishing_path = self._validate_('Publishing.Path')
+        self.publishing_path = ticket['Publishing.Path']
 
     def _validate_(self, key, optional=False):
         value = None
@@ -243,23 +243,6 @@ class PublishingTicket(Ticket):
 
         # googlechat properties
         self.googlechat_webhook_url = self._validate_('Publishing.Googlechat.Webhook', True)
-
-    def _validate_(self, key, optional=False):
-        value = None
-        if key in self.__tracker_ticket:
-            value = self.__tracker_ticket[key]
-            if not value and not optional:
-                logging.debug(key + ' is empty in ticket')
-                raise TicketException(key + ' is empty in ticket')
-            else:
-                value = str(value)
-        else:
-            if optional:
-                logging.debug("optional property was not in ticket: " + key)
-            else:
-                logging.debug(key + ' is missing in ticket')
-                raise TicketException(key + ' is missing in ticket')
-        return value
 
     def get_raw_property(self, key, optional=True):
         value = None

--- a/voctopublish/model/ticket_module.py
+++ b/voctopublish/model/ticket_module.py
@@ -222,6 +222,13 @@ class PublishingTicket(Ticket):
             self.recording_id = self._validate_('Voctoweb.RecordingId.Master', True)
             self.voctoweb_event_id = self._validate_('Voctoweb.EventId', True)
 
+        # rclone properties
+        # this is a not-very-often-used property, so we add a default for it
+        self.rclone_enabled = self._validate_('Publishing.Rclone.Enable', True) == 'yes'
+        if self.rclone_enabled:
+            self.rclone_destination = self._validate_('Publishing.Rclone.Destination')
+            self.rclone_only_master = self._validate_('Publishing.Rclone.OnlyMaster') == 'yes'
+
         # twitter properties
         if self._validate_('Publishing.Twitter.Enable') == 'yes':
             self.twitter_enable = True

--- a/voctopublish/tools/thumbnails.py
+++ b/voctopublish/tools/thumbnails.py
@@ -23,7 +23,7 @@ from shutil import move
 from subprocess import CalledProcessError, check_output
 from tempfile import TemporaryDirectory
 
-from select_thumbnail import calc_score
+from tools.select_thumbnail import calc_score
 from model.ticket_module import Ticket
 
 

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -107,12 +107,12 @@ class Worker:
         except Exception as e_:
             raise PublisherException('Config parameter missing or empty, please check config') from e_
 
+        self.ticket = self._get_ticket_from_tracker()
+
     def publish(self):
         """
         Decide based on the information provided by the tracker where to publish.
         """
-        self.ticket = self._get_ticket_from_tracker()
-
         if not self.ticket:
             logging.debug('not ticket, returning')
             return

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -45,6 +45,7 @@ class Worker:
 
     def __init__(self):
         self.ticket = None
+        self.ticket_id = None
         self.thumbs = None
         # load config
         if not os.path.exists('client.conf'):
@@ -201,6 +202,7 @@ class Worker:
                                                                  {'EncodingProfile.Slug': 'relive'})
         if ticket_meta:
             ticket_id = ticket_meta['id']
+            self.ticket_id = ticket_id
             logging.info("Ticket ID:" + str(ticket_id))
             try:
                 ticket_properties = self.c3tt.get_ticket_properties(ticket_id)
@@ -492,7 +494,7 @@ if __name__ == '__main__':
     try:
         w.get_ticket_from_tracker()
     except Exception as e:
-        w.c3tt.set_ticket_failed(w.ticket.id, '%s: %s' % (exc_type.__name__, e))
+        w.c3tt.set_ticket_failed(w.ticket_id, '%s: %s' % (exc_type.__name__, e))
 
     if w.ticket:
         if w.worker_type == 'releasing':
@@ -500,7 +502,7 @@ if __name__ == '__main__':
                 w.publish()
             except Exception as e:
                 exc_type, exc_obj, exc_tb = sys.exc_info()
-                w.c3tt.set_ticket_failed(w.ticket.id, '%s: %s' % (exc_type.__name__, e))
+                w.c3tt.set_ticket_failed(w.ticket_id, '%s: %s' % (exc_type.__name__, e))
                 logging.exception(e)
                 sys.exit(-1)
         elif w.worker_type == 'recording':
@@ -508,12 +510,12 @@ if __name__ == '__main__':
                 w.download()
             except Exception as e:
                 exc_type, exc_obj, exc_tb = sys.exc_info()
-                w.c3tt.set_ticket_failed(w.ticket.id, '%s: %s' % (exc_type.__name__, e))
+                w.c3tt.set_ticket_failed(w.ticket_id, '%s: %s' % (exc_type.__name__, e))
                 logging.exception(e)
                 sys.exit(-1)
         else:
-            logging.error('unknown ticket type')
-            w.c3tt.set_ticket_failed('unknown ticket type')
+            logging.error(f'unknown worker type {w.worker_type}')
+            w.c3tt.set_ticket_failed(w.ticket_id, f'unknown worker ticket type {w.worker_type}')
             sys.exit(-1)
     else:
         sys.exit(0)

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -129,7 +129,7 @@ class Worker:
                 raise IOError("Output path is not writable (%s)" % self.ticket.publishing_path)
 
         self.thumbs = ThumbnailGenerator(self.ticket, self.config)
-        if not self.thumbs.exists():
+        if not self.thumbs.exists:
             self.thumbs.generate()
 
         logging.debug("#voctoweb {} {}  ".format(self.ticket.profile_voctoweb_enable, self.ticket.voctoweb_enable))

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -165,7 +165,7 @@ class Worker:
                 ret = rclone.upload()
                 if ret not in (0, 9):
                     raise PublisherException(f"rclone failed with exit code {ret}")
-                self.c3tt.set_ticket_properties({
+                self.c3tt.set_ticket_properties(self.ticket_id, {
                     'Rclone.DestinationFileName': rclone.destination,
                     'Rclone.ReturnCode': str(ret),
                 })
@@ -256,7 +256,7 @@ class Worker:
                     logging.debug('response: ' + str(r.json()))
                     try:
                         # TODO only set recording id when new recording was created, and not when it was only updated
-                        self.c3tt.set_ticket_properties(self, {'Voctoweb.EventId': r.json()['id']})
+                        self.c3tt.set_ticket_properties(self.ticket_id, {'Voctoweb.EventId': r.json()['id']})
                     except Exception as e_:
                         raise PublisherException('failed to Voctoweb EventID to ticket') from e_
 
@@ -308,7 +308,7 @@ class Worker:
 
         # when the ticket was created, and not only updated: write recording_id to ticket
         if recording_id:
-            self.c3tt.set_ticket_properties({'Voctoweb.RecordingId.Master': recording_id})
+            self.c3tt.set_ticket_properties(self.ticket_id, {'Voctoweb.RecordingId.Master': recording_id})
 
     def _mux_to_single_language(self, vw):
         """
@@ -349,7 +349,7 @@ class Worker:
             try:
                 # when the ticket was created, and not only updated: write recording_id to ticket
                 if recording_id:
-                    self.c3tt.set_ticket_properties(
+                    self.c3tt.set_ticket_properties(self.ticket_id,
                         {'Voctoweb.RecordingId.' + self.ticket.languages[language]: str(recording_id)})
             except Exception as e_:
                 raise PublisherException('failed to set RecordingId to ticket') from e_
@@ -368,7 +368,7 @@ class Worker:
         for i, youtubeUrl in enumerate(youtube_urls):
             props['YouTube.Url' + str(i)] = youtubeUrl
 
-        self.c3tt.set_ticket_properties(self.ticket, props)
+        self.c3tt.set_ticket_properties(self.ticket_id, props)
         self.ticket.youtube_urls = props
 
         # now, after we reported everything back to the tracker, we try to add the videos to our own playlists
@@ -398,7 +398,7 @@ class Worker:
 
         # set recording language TODO multilang
         try:
-            self.c3tt.set_ticket_properties({'Record.Language': self.ticket.language})
+            self.c3tt.set_ticket_properties(self.ticket_id, {'Record.Language': self.ticket.language})
         except AttributeError as err_:
             self.c3tt.set_ticket_failed('unknown language, please set language in the recording ticket to proceed')
             logging.error('unknown language, please set language in the recording ticket to proceed')

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -166,6 +166,10 @@ class Worker:
                 ret = rclone.upload()
                 if ret not in (0, 9):
                     raise PublisherException(f"rclone failed with exit code {ret}")
+                self.c3tt.set_ticket_properties({
+                    'Rclone.DestinationFileName': rclone.destination,
+                    'Rclone.ReturnCode': str(ret),
+                })
             else:
                 logging.debug(
                     "skipping rclone because Publishing.Rclone.OnlyMaster is set to 'yes'"

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -211,9 +211,9 @@ class Worker:
                 self.c3tt.set_ticket_failed(ticket_id, e_)
                 raise e_
             if self.ticket_type == 'encoding':
-                return PublishingTicket(ticket_meta, ticket_properties)
+                return PublishingTicket(ticket_properties, ticket_id)
             elif self.ticket_type == 'releasing':
-                return RecordingTicket
+                return RecordingTicket(ticket_properties, ticket_id)
             else:
                 logging.info('Unknown ticket type ' + self.ticket_type + ' aborting, please check config ')
                 raise PublisherException("Unknown ticket type " + self.ticket_type)

--- a/voctopublish/voctopublish.py
+++ b/voctopublish/voctopublish.py
@@ -494,6 +494,7 @@ if __name__ == '__main__':
     try:
         w.get_ticket_from_tracker()
     except Exception as e:
+        exc_type, exc_obj, exc_tb = sys.exc_info()
         w.c3tt.set_ticket_failed(w.ticket_id, '%s: %s' % (exc_type.__name__, e))
 
     if w.ticket:


### PR DESCRIPTION
This adds the possibility to upload to a cloud storage service using `rclone`. Paths to the rclone binary and configs will get taken from the voctopublish configuration, the actual upload destination is configurable inside the tracker project.

To use this feature, you have to add the following to your voctopublish config:
```ini
[rclone]
exe_path = /opt/rclone/rclone
config_path = /opt/rclone/config
```

This adds the following tracker properties:
* `Publishing.Rclone.Enable` (`yes`/`no`) - Whether to enable rclone syncing for this ticket/project
* `Publishing.Rclone.OnlyMaster` (`yes`/`no`) - Whether to upload only master encodings or all encoded files
* `Publishing.Rclone.Destination` - rclone-style destination identifier.

On publish, the following properties will get written back to the tracker:
* `Rclone.DestinationFileName` - `Publishing.Rclone.Destination`, but with all placeholders resolved
* `Rclone.ReturnCode` - return code of the `rclone` call

`Publishing.Rclone.Destination` will be formatted via pythons `.format()` attribute. You may use the following placeholders:
* `{day}`, `{month}`, `{year}` - Date of the talk
* `{fahrplan_day}` - Fahrplan Day
* `{event}` - Event acronym as set in tracker
* `{filename_short}` - Consists of the fahrplan id and a format specifier, for example `42-hd.mp4`
* `{filename_full}` - Consists of the fahrplan slug (`EncodingProfile.BaseName`, to be exact), for example `myconference-32-my-cool-talk.mp4`
* `{filename_guid}` - Consists of the fahrplan GUID of the talk, for example `40e1e399-bb5f-4219-8dfe-a0ebf24b29ff.mp4`
* `{format}` - Contents of `EncodingProfile.MirrorFolder`


*Note:* Configuring rclone is not done by this client. It is expected for the voctopublish admin to instruct their users about the possible rclone destinations.